### PR TITLE
 Store all images on get_cover_image for future use

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -732,6 +732,7 @@ class _Request(object):
     """Representing an abstract web service operation."""
 
     def __init__(self, network, method_name, params=None):
+        print(method_name)
 
         if params is None:
             params = {}
@@ -1501,11 +1502,10 @@ class Album(_Opus):
             SIZE_SMALL
         """
         if not self.images:
-            return _extract_all(
+            self.images = _extract_all(
                 self._request(self.ws_prefix + ".getInfo", cacheable=True),
-                'image')[size]
-        else:
-            return self.images[size]
+                'image')
+        return self.images[size]
 
     def get_tracks(self):
         """Returns the list of Tracks on this album."""

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -1369,7 +1369,8 @@ class _Opus(_BaseObject, _Taggable):
 
     __hash__ = _BaseObject.__hash__
 
-    def __init__(self, artist, title, network, ws_prefix, username=None, images=None):
+    def __init__(self, artist, title, network, ws_prefix, username=None,
+                 images=None):
         """
         Create an opus instance.
         # Parameters:
@@ -1487,7 +1488,8 @@ class Album(_Opus):
     __hash__ = _Opus.__hash__
 
     def __init__(self, artist, title, network, username=None, images=None):
-        super(Album, self).__init__(artist, title, network, "album", username, images)
+        super(Album, self).__init__(artist, title, network, "album", username,
+                                    images)
 
     def get_cover_image(self, size=SIZE_EXTRA_LARGE):
         """
@@ -1500,8 +1502,8 @@ class Album(_Opus):
         """
         if not self.images:
             return _extract_all(
-                self._request(
-                    self.ws_prefix + ".getInfo", cacheable=True), 'image')[size]
+                self._request(self.ws_prefix + ".getInfo", cacheable=True),
+                'image')[size]
         else:
             return self.images[size]
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -315,6 +315,26 @@ class TestPyLastNetwork(PyLastTestCase):
         self.assertIsInstance(results, list)
         self.assertIsInstance(results[0], pylast.Album)
 
+    def test_album_search_images(self):
+        # Arrange
+        album = "Nevermind"
+        search = self.network.search_for_album(album)
+
+        # Act
+        results = search.get_next_page()
+        images = results[0].images
+
+        # Assert
+        self.assertEqual(len(images), 4)
+
+        self.assertTrue(images[pylast.SIZE_SMALL].startswith("https://"))
+        self.assertTrue(images[pylast.SIZE_SMALL].endswith(".png"))
+        self.assertIn("/34s/", images[pylast.SIZE_SMALL])
+
+        self.assertTrue(images[pylast.SIZE_EXTRA_LARGE].startswith("https://"))
+        self.assertTrue(images[pylast.SIZE_EXTRA_LARGE].endswith(".png"))
+        self.assertIn("/300x300/", images[pylast.SIZE_EXTRA_LARGE])
+
     def test_artist_search(self):
         # Arrange
         artist = "Nirvana"


### PR DESCRIPTION
For https://github.com/pylast/pylast/issues/261.

Thanks for https://github.com/pylast/pylast/pull/262!

Looks good, here's a few small changes. Merging this PR will update that PR.

Changes proposed in this pull request:

 *  Store all images on get_cover_image for future use
 * Add test for storing album images on search
 * Fix flake8 warnings
